### PR TITLE
🐛 --env-files オプションに空白入りパスを入れると不具合が起きる問題を修正

### DIFF
--- a/src/KnoqReminder.App/KnoqReminder.App/Configurations/ConfigurationExtension.cs
+++ b/src/KnoqReminder.App/KnoqReminder.App/Configurations/ConfigurationExtension.cs
@@ -17,14 +17,6 @@ static class ConfigurationExtension
                 }
                 GenericThrowHelper.Throw<FileNotFoundException>($"Configuration file not found: {fullPath}");
             }
-            else if (File.GetAttributes(fullPath).HasFlag(FileAttributes.Directory))
-            {
-                if (areOptional)
-                {
-                    continue;
-                }
-                GenericThrowHelper.Throw<IOException>($"Configuration path is a directory: {fullPath}");
-            }
             using var stream = File.OpenRead(fullPath);
             builder.AddIniStream(stream);
         }

--- a/src/KnoqReminder.App/KnoqReminder.App/Configurations/ConfigurationExtension.cs
+++ b/src/KnoqReminder.App/KnoqReminder.App/Configurations/ConfigurationExtension.cs
@@ -17,6 +17,14 @@ static class ConfigurationExtension
                 }
                 GenericThrowHelper.Throw<FileNotFoundException>($"Configuration file not found: {fullPath}");
             }
+            else if (File.GetAttributes(fullPath).HasFlag(FileAttributes.Directory))
+            {
+                if (areOptional)
+                {
+                    continue;
+                }
+                GenericThrowHelper.Throw<IOException>($"Configuration path is a directory: {fullPath}");
+            }
             using var stream = File.OpenRead(fullPath);
             builder.AddIniStream(stream);
         }

--- a/src/KnoqReminder.App/KnoqReminder.App/Properties/launchSettings.json
+++ b/src/KnoqReminder.App/KnoqReminder.App/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "http": {
       "commandName": "Project",
-      "commandLineArgs": "--env-files $(SolutionDir).env.dev",
+      "commandLineArgs": "--env-files \"$(SolutionDir).env.dev\"",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -13,7 +13,7 @@
     },
     "https": {
       "commandName": "Project",
-      "commandLineArgs": "--env-files $(SolutionDir).env.dev",
+      "commandLineArgs": "--env-files \"$(SolutionDir).env.dev\"",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 環境ファイルパスの処理を改善し、スペースを含むパスでのアプリケーション起動が確実に行われるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->